### PR TITLE
Updated go-bindata link to maintained fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Package gitfs is a complete solution for static files in Go code.
 
 When Go code uses non-Go files, they are not packaged into the binary.
 The common approach to the problem, as implemented by
-[go-bindata](https://github.com/jteeuwen/go-bindata)
+[go-bindata](https://github.com/kevinburke/go-bindata)
 is to convert all the required static files into Go code, which
 eventually compiled into the binary.
 

--- a/gitfs.go
+++ b/gitfs.go
@@ -2,7 +2,7 @@
 //
 // When Go code uses non-Go files, they are not packaged into the binary.
 // The common approach to the problem, as implemented by
-// (go-bindata) https://github.com/jteeuwen/go-bindata
+// (go-bindata) https://github.com/kevinburke/go-bindata
 // is to convert all the required static files into Go code, which
 // eventually compiled into the binary.
 //


### PR DESCRIPTION
Just a minor thing, I noticed that the go-bindata repo that you linked to was unmaintained and this is just nice for people link me who are clicking around looking at different solutions.

Thanks